### PR TITLE
libspf now handles SPF RRs in linux (libresolv)

### DIFF
--- a/src/libspf2/spf_dns_cache.c
+++ b/src/libspf2/spf_dns_cache.c
@@ -342,7 +342,7 @@ SPF_dns_cache_rr_fixup(SPF_dns_cache_config_t *spfhook,
 		cached_rr->ttl = spfhook->min_ttl;
 
     if ( cached_rr->ttl < spfhook->txt_ttl
-			&& cached_rr->rr_type == ns_t_txt )
+			&& (cached_rr->rr_type == ns_t_txt || cached_rr->rr_type == ns_t_spf))
 		cached_rr->ttl = spfhook->txt_ttl;
 
     if ( cached_rr->ttl < spfhook->err_ttl

--- a/src/libspf2/spf_dns_resolv.c
+++ b/src/libspf2/spf_dns_resolv.c
@@ -179,14 +179,15 @@ SPF_dns_resolv_debug(SPF_dns_server_t *spf_dns_server, ns_rr rr,
 				SPF_debugf("MX: %d %s", prio, name_buf);
 			break;
 
+		case ns_t_spf:
 		case ns_t_txt:
 			if (rdlen < 1) {
-				SPF_debugf("TXT: rdlen too short: %lu", (unsigned long)rdlen);
+				SPF_debugf(ns_rr_type(rr) == ns_t_txt ? "TXT" : "SPF" ": rdlen too short: %lu", (unsigned long)rdlen);
 				break;
 			}
 			/* XXX I think this is wrong/unsafe. Shevek. */
 			/* XXX doesn't parse the different TXT "sections" */
-			SPF_debugf("TXT: (%lu) \"%.*s\"",
+			SPF_debugf(ns_rr_type(rr) == ns_t_txt ? "TXT" : "SPF" ": (%lu) \"%.*s\"",
 					(unsigned long)rdlen, (int)rdlen - 1, rdata + 1);
 			break;
 
@@ -510,6 +511,7 @@ SPF_dns_resolv_lookup(SPF_dns_server_t *spf_dns_server,
 					cnt++;
 					break;
 
+				case ns_t_spf:
 				case ns_t_txt:
 					if (rdlen > 1) {
 						u_char *src, *dst;


### PR DESCRIPTION
Hi,

I noticed that libspf2 wasn't using SPF RRs.  When I investigated it was due to "ns_t_spf" not being handled upon reception of the DNS response.  The fix for this is trivial as mst of the hard work in getting SPF RRs included was already done.

I also added a small change into the cache so that SPF RRs are treated the same as TXT RRs.

Thanks,
ddave1

P.S.  I'm new to git, when I tried to add your repo as a remote it wouldn't work.  I need to use the http link due to firewall restrictions but I get a 403 when I try to fetch.
