### PR TITLE
option to use unbound to configure timeouts

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -8,7 +8,8 @@ else
     set -x
 
     aclocal -I config
+    libtoolize --force
     autoheader
-    automake --gnu --add-missing 
+    automake --gnu --add-missing
     autoconf
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -91,6 +91,7 @@ AC_CHECK_HEADERS([limits.h sys/param.h syslog.h sys/time.h errno.h sys/types.h])
 AC_CHECK_HEADERS([fcntl.h malloc.h nmemory.h stddef.h inttypes.h stdlib.h string.h strings.h unistd.h stdarg.h])
 AC_CHECK_HEADERS([pthread.h pwd.h grp.h libintl.h getopt.h])
 AC_CHECK_HEADERS([netdb.h netinet/in.h sys/socket.h arpa/inet.h arpa/nameser.h])
+AC_CHECK_HEADERS([unbound.h])
 AC_CHECK_HEADERS([resolv.h], [], [], [[
 	#if HAVE_SYS_TYPES_H
 	#  include <sys/types.h>
@@ -149,6 +150,7 @@ AC_CHECK_LIB(nsl, inet_pton)
 AC_CHECK_LIB(socket, socket)
 AC_CHECK_LIB(intl, gettext)
 AC_CHECK_LIB(pthread, pthread_create)
+AC_CHECK_LIB(unbound, ub_ctx_create)
 
 
 # Checks for typedefs, structures, and compiler characteristics.

--- a/src/include/spf_dns.h
+++ b/src/include/spf_dns.h
@@ -67,7 +67,6 @@
 #include <unbound.h>
 #endif
 
-
 /*
  * For those who don't have <arpa/nameserv.h>
  */
@@ -136,6 +135,10 @@ typedef SPF_errcode_t (*SPF_dns_get_exp_t)( SPF_server_t *spf_server,
 typedef int (*SPF_dns_add_cache_t)( SPF_server_t *spf_server,
 				    SPF_dns_rr_t spfrr );
 
+#ifdef HAVE_UNBOUND_H
+typedef struct unbound_cb_data unbound_cb_data_t;
+#endif
+
 struct SPF_dns_server_struct
 {
 	/** The destructor for this SPF_dns_server_t. If this is NULL, then
@@ -158,9 +161,17 @@ struct SPF_dns_server_struct
     void				*hook;		/* server-specific data */
 #if HAVE_UNBOUND_H
     struct ub_ctx* uctx;  /* unbound context shared across threads */
+    double dns_timeout;   /* DNS timeout */
 #endif
 };
 
+#ifdef HAVE_UNBOUND_H
+struct unbound_cb_data {
+  u_char *responsebuf;
+  size_t responselen;
+  int err;
+};
+#endif
 
 void			 SPF_dns_free( SPF_dns_server_t *spf_dns_server );
 SPF_dns_rr_t	*SPF_dns_lookup( SPF_dns_server_t *spf_dns_server,

--- a/src/include/spf_dns.h
+++ b/src/include/spf_dns.h
@@ -63,6 +63,10 @@
  * 
  */
 
+#ifdef HAVE_UNBOUND_H
+#include <unbound.h>
+#endif
+
 
 /*
  * For those who don't have <arpa/nameserv.h>
@@ -152,6 +156,9 @@ struct SPF_dns_server_struct
     const char			*name;		/* name of the layer		*/
 	int					 debug;
     void				*hook;		/* server-specific data */
+#if HAVE_UNBOUND_H
+    struct ub_ctx* uctx;  /* unbound context shared across threads */
+#endif
 };
 
 

--- a/src/include/spf_server.h
+++ b/src/include/spf_server.h
@@ -80,6 +80,10 @@ SPF_errcode_t	 SPF_server_set_rec_dom(SPF_server_t *sp,
 					const char *dom);
 SPF_errcode_t	 SPF_server_set_sanitize(SPF_server_t *sp,
 					int sanitize);
+#ifdef HAVE_UNBOUND_H
+SPF_errcode_t	 SPF_server_set_dns_timeout(SPF_server_t *sp,
+					double sanitize);
+#endif
 SPF_errcode_t	 SPF_server_set_explanation(SPF_server_t *sp,
 					const char *exp, SPF_response_t **spf_responsep);
 SPF_errcode_t	 SPF_server_set_localpolicy(SPF_server_t *sp,

--- a/src/libspf2/spf_dns_resolv.c
+++ b/src/libspf2/spf_dns_resolv.c
@@ -209,6 +209,30 @@ SPF_dns_resolv_debug(SPF_dns_server_t *spf_dns_server, ns_rr rr,
 
 }
 
+#if HAVE_UNBOUND_H
+/* This is called when resolution is completed */
+void unbound_mycallback(void* mydata, int err, struct ub_result* result)
+{
+  unbound_cb_data_t *ub_data = (unbound_cb_data_t *)mydata;
+
+  int num = 0;
+  int i;
+
+  ub_data->err = err;
+  if(err != 0) {
+    return;
+  }
+
+  if (result->answer_len > 0) {
+    ub_data->responsebuf = (u_char *)malloc(result->answer_len);
+    memcpy(ub_data->responsebuf, result->answer_packet, result->answer_len);
+  }
+  ub_data->responselen = result->answer_len;
+  ub_resolve_free(result);
+}
+#endif
+
+
 /**
  * Can return NULL on out-of-memory condition.
  * Should return a HOST_NOT_FOUND or appropriate rr in all other
@@ -268,6 +292,71 @@ SPF_dns_resolv_lookup(SPF_dns_server_t *spf_dns_server,
 	}
 #endif
 
+#if HAVE_UNBOUND_H
+  unbound_cb_data_t *ub_cb_data;
+  int async_id = 0;
+
+  /* initialize ub_cb_data */
+  ub_cb_data = (unbound_cb_data_t*)malloc(sizeof(unbound_cb_data_t*));
+  ub_cb_data->responsebuf = NULL;
+  ub_cb_data->responselen = 0;
+  ub_cb_data->err = 0;
+
+  /* asynchronous query */
+  int retval = ub_resolve_async(spf_dns_server->uctx, domain,
+    rr_type,
+    1 /* CLASS IN (internet) */,
+    (void*)ub_cb_data, unbound_mycallback, &async_id);
+
+  if(retval != 0) {
+    SPF_debugf("unbound query failed: %s\n", ub_strerror(retval));
+    free(ub_cb_data);
+    return SPF_dns_rr_new_init(spf_dns_server,
+            domain, rr_type, 0, SPF_h_errno);
+  }
+
+  /* wait for the async query to finish or timeout */  
+  struct timeval timeout;
+  fd_set rfds;
+  double dns_timeout = spf_dns_server->dns_timeout;
+  timeout.tv_sec = (int)dns_timeout;
+  timeout.tv_usec = (dns_timeout - timeout.tv_sec) * 1000000;
+  SPF_debugf("Timeout is %d:%d", timeout.tv_sec, timeout.tv_usec);
+  int ufd = ub_fd(spf_dns_server->uctx);
+  FD_ZERO(&rfds);
+  FD_SET(ufd, &rfds);
+  int result = select(ufd+1, &rfds, NULL, NULL, &timeout);
+  if (result > 0) {
+    retval = ub_process(spf_dns_server->uctx);
+    if(retval != 0 || ub_cb_data->err != 0) {
+      SPF_debugf("unbound resolve error: %s\n", ub_strerror(retval));
+      free(ub_cb_data);
+      return SPF_dns_rr_new_init(spf_dns_server,
+              domain, rr_type, 0, SPF_h_errno);
+    }
+  } else {
+    SPF_debugf("Cancelling unbound query %d", async_id);
+    retval = ub_cancel(spf_dns_server->uctx, async_id);
+    free(ub_cb_data);
+    return SPF_dns_rr_new_init(spf_dns_server,
+            domain, rr_type, 0, SPF_h_errno);
+
+  }
+  
+  SPF_debugf("ubx domain %s", domain);
+  SPF_debugf("ubx result len %d", ub_cb_data->responselen);
+  if (ub_cb_data->responselen > 0) {
+    responselen = ub_cb_data->responselen;
+    responsebuf =  ub_cb_data->responsebuf;
+    free(ub_cb_data);
+  } else {
+    free(ub_cb_data);
+    SPF_debugf("query failed - no response found");
+    return SPF_dns_rr_new_init(spf_dns_server,
+            domain, rr_type, 0, SPF_h_errno);
+  }
+
+#else
 	responselen = 2048;
 	responsebuf = (u_char *)malloc(responselen);
 	if (! responsebuf)
@@ -291,30 +380,7 @@ SPF_dns_resolv_lookup(SPF_dns_server_t *spf_dns_server,
 	 * enough to receive a maximum UDP response from the server or parts of the answer
 	 * will be silently discarded. The default maximum UDP response size is 512 bytes.
 	 */
-#if HAVE_UNBOUND_H
-  /* query for webserver */
-  struct ub_result* result;
-  
-  int retval = ub_resolve(spf_dns_server->uctx, domain, 
-    rr_type /* TYPE A (IPv4 address) */, 
-    1 /* CLASS IN (internet) */, &result);
-  if(retval != 0) {
-    SPF_debugf("retval query failed: %s\n", ub_strerror(retval));
-    return SPF_dns_rr_new_init(spf_dns_server,
-            domain, rr_type, 0, SPF_h_errno);
-  }  
-  SPF_debugf("ubx result len %d", result->answer_len);
-  SPF_debugf("ubx domain %s", domain);
-  SPF_debugf("ubx type %d", rr_type);
-  if (result->answer_len > 0) {
-    memcpy(responsebuf, result->answer_packet, result->answer_len);
-    responselen = result->answer_len;
-  } else {
-    SPF_debugf("query failed: %s\n", ub_strerror(retval));
-    return SPF_dns_rr_new_init(spf_dns_server,
-            domain, rr_type, 0, SPF_h_errno);
-  }
-#else
+
 	for (;;) {
 		int	dns_len;
 
@@ -681,6 +747,11 @@ SPF_dns_resolv_new(SPF_dns_server_t *layer_below,
     SPF_error("Couldn't create unbound context");
   else
     SPF_debugf("ubx success");
+
+  /* use resolv.conf */
+  if (ub_ctx_resolvconf(spf_dns_server->uctx, "/etc/resolv.conf"))
+    SPF_error("unbound error setting resolv.conf");
+    
 #endif
 
 	return spf_dns_server;

--- a/src/libspf2/spf_server.c
+++ b/src/libspf2/spf_server.c
@@ -126,6 +126,11 @@ SPF_server_new_common_post(SPF_server_t *sp)
 			SPF_error("Response errors compiling default whitelist");
 		SPF_response_free(spf_response);
 	}
+
+#if HAVE_UNBOUND_H
+  // set the default dns timeout to be 5 seconds
+  SPF_server_set_dns_timeout(sp, 5.0);
+#endif
 }
 
 SPF_server_t *
@@ -230,6 +235,20 @@ SPF_server_set_sanitize(SPF_server_t *sp, int sanitize)
 	sp->sanitize = sanitize;
 	return SPF_E_SUCCESS;
 }
+
+#if HAVE_UNBOUND_H
+SPF_errcode_t
+SPF_server_set_dns_timeout(SPF_server_t *sp, double dns_timeout)
+{
+  sp->resolver->dns_timeout = dns_timeout;
+  if (sp->resolver->layer_below) {
+    SPF_debugf("Setting timeout for the server %d", (int)dns_timeout);
+    SPF_dns_server_t *resolver = sp->resolver->layer_below;
+	  resolver->dns_timeout = dns_timeout;
+  } 
+	return SPF_E_SUCCESS;
+}
+#endif
 
 SPF_errcode_t
 SPF_server_set_explanation(SPF_server_t *sp, const char *exp,


### PR DESCRIPTION
unbound is an async dns library and provides features like DNSSEC, caching, etc.
