### PR TITLE
return explanation and Received-SPF header for result=none…

### DIFF
--- a/src/libspf2/spf_interpret.c
+++ b/src/libspf2/spf_interpret.c
@@ -380,7 +380,7 @@ SPF_i_set_received_spf(SPF_response_t *spf_response)
  * This must be called with EITHER
  * spf_response->spf_record_exp != NULL
  *   OR
- * result in { SPF_RESULT_PASS SPF_RESULT_INVALID
+ * result in { SPF_RESULT_NONE SPF_RESULT_PASS SPF_RESULT_INVALID
  *		SPF_RESULT_TEMPERROR SPF_RESULT_PERMERROR }
  * or the library will abort when it tries to generate an explanation.
  */

--- a/src/libspf2/spf_server.c
+++ b/src/libspf2/spf_server.c
@@ -361,8 +361,9 @@ retry:
 			}
 			spf_response->result = SPF_RESULT_NONE;
 			spf_response->reason = SPF_REASON_FAILURE;
-			return SPF_response_add_error(spf_response, SPF_E_NOT_SPF,
-					"Host '%s' not found.", domain);
+			return SPF_i_done(spf_response, SPF_RESULT_NONE, SPF_REASON_FAILURE,
+					SPF_response_add_error(spf_response, SPF_E_NOT_SPF,
+						"Host '%s' not found.", domain));
 			// break;
 
 		case NO_DATA:
@@ -375,8 +376,9 @@ retry:
 			}
 			spf_response->result = SPF_RESULT_NONE;
 			spf_response->reason = SPF_REASON_FAILURE;
-			return SPF_response_add_error(spf_response, SPF_E_NOT_SPF,
-					"No DNS data for '%s'.", domain);
+			return SPF_i_done(spf_response, SPF_RESULT_NONE, SPF_REASON_FAILURE,
+					SPF_response_add_error(spf_response, SPF_E_NOT_SPF,
+						"No DNS data for '%s'.", domain));
 			// break;
 
 		case TRY_AGAIN:
@@ -469,17 +471,18 @@ retry:
 		}
 		spf_response->result = SPF_RESULT_NONE;
 		spf_response->reason = SPF_REASON_FAILURE;
-		return SPF_response_add_error(spf_response, SPF_E_NOT_SPF,
-				"No SPF records for '%s'", domain);
+		return SPF_i_done(spf_response, SPF_RESULT_NONE, SPF_REASON_FAILURE,
+				SPF_response_add_error(spf_response, SPF_E_NOT_SPF,
+					"No SPF records for '%s'", domain));
 	}
 	if (num_found > 1) {
 		SPF_dns_rr_free(rr_txt);
 		// rfc4408 requires permerror here.
-		/* XXX This could be refactored with SPF_i_done. */
 		spf_response->result = SPF_RESULT_PERMERROR;
 		spf_response->reason = SPF_REASON_FAILURE;
-		return SPF_response_add_error(spf_response, SPF_E_MULTIPLE_RECORDS,
-				"Multiple SPF records for '%s'", domain);
+		return SPF_i_done(spf_response, SPF_RESULT_PERMERROR, SPF_REASON_FAILURE,
+				SPF_response_add_error(spf_response, SPF_E_MULTIPLE_RECORDS,
+					"Multiple SPF records for '%s'", domain));
 	}
 
 	/* try to compile the SPF record */


### PR DESCRIPTION
… and in case of multiple SPF records (permerror).

Currently, we don't get any explanation string or Received-SPF header if there is no SPF record (result=none) or there is more than one record (result=permerror).

For this patch to work you need the modification from fc02a07a07f3718a687f04134c6d56460e41e793 in spf_interpret.c (it is included in master, but maybe not in the sources of projects that want to include this patch).

*Note: This patch [has been applied](https://packages.qa.debian.org/libs/libspf2/news/20160325T171921Z.html) to the Debian package as of version `1.2.10-7` (2016-05-25)*