### PR TITLE
Removed a GNUism in the C99-style variadic macros for SPF_errorf etc.

### DIFF
--- a/src/include/spf_log.h
+++ b/src/include/spf_log.h
@@ -60,10 +60,10 @@ void SPF_debugv( const char *file, int line, const char *format, va_list ap ) __
 
 #if defined( __STDC_VERSION__ ) && __STDC_VERSION__ >= 199901L
 
-#define SPF_errorf(format, ... ) SPF_errorx( __FILE__, __LINE__, format, ##__VA_ARGS__ )
-#define SPF_warningf(format, ... ) SPF_warningx( __FILE__, __LINE__, format, ##__VA_ARGS__ )
-#define SPF_infof(format, ... ) SPF_infox( __FILE__, __LINE__, format, ##__VA_ARGS__ )
-#define SPF_debugf(format, ... ) SPF_debugx( __FILE__, __LINE__, format, ##__VA_ARGS__ )
+#define SPF_errorf(... ) SPF_errorx( __FILE__, __LINE__, __VA_ARGS__ )
+#define SPF_warningf(... ) SPF_warningx( __FILE__, __LINE__, __VA_ARGS__ )
+#define SPF_infof(... ) SPF_infox( __FILE__, __LINE__, __VA_ARGS__ )
+#define SPF_debugf(... ) SPF_debugx( __FILE__, __LINE__, __VA_ARGS__ )
 
 #elif defined( __GNUC__ )
 


### PR DESCRIPTION
The current method is AFAIK gcc-specific, whereas the previous one also seemed to depend on gcc-specific behaviour. This method should be fully C99 compliant.
