### PR TITLE
fix use-after-free

### DIFF
--- a/src/libspf2/spf_request.c
+++ b/src/libspf2/spf_request.c
@@ -259,6 +259,7 @@ SPF_request_query_record(SPF_request_t *spf_request,
 	err = SPF_record_interpret(spf_record,
 					spf_request, spf_response, 0);
 	SPF_record_free(spf_record);
+	spf_response->spf_record_exp = NULL;
 
 	return err;
 }


### PR DESCRIPTION
Not sure what the intention is here, but in no case should spf_record_exp point to a freed object. (Fixes crash on OpenBSD 5.9.)