### PR TITLE
Expand Hostname Buffer

### DIFF
--- a/src/libspf2/spf_server.c
+++ b/src/libspf2/spf_server.c
@@ -67,14 +67,14 @@ __attribute__((warn_unused_result))
 static SPF_errcode_t
 SPF_server_set_rec_dom_ghbn(SPF_server_t *sp)
 {
-	sp->rec_dom = malloc(HOST_NAME_MAX);
+	sp->rec_dom = malloc(HOST_NAME_MAX+1);
 	if (! sp->rec_dom)
 		return SPF_E_NO_MEMORY;
 #ifdef _WIN32
 	gethostnameFQDN(sp->rec_dom, HOST_NAME_MAX);
 	return 0;	/* XXX FIXME? */
 #else
-	if (gethostname(sp->rec_dom, HOST_NAME_MAX) < 0)
+	if (gethostname(sp->rec_dom, HOST_NAME_MAX+1) < 0)
 		/* XXX Error using strerror. */
 		return SPF_E_INTERNAL_ERROR;
 #endif


### PR DESCRIPTION
The buffer holding the results for gethostname now contains
HOST_NAME_MAX + 1 characters so it may contain hostnames at
HOST_NAME_MAX printable characters and a terminating null.

Prior to this change, the buffer could only accomodate hostnames
of HOST_NAME_MAX - 1 characters.

If you had a hostname that was HOST_NAME_MAX  (64 characters on Linux) 
with the old buffer, the call to gethostname(...) would succeed but truncate
the hostname (the truncation behavior is not fully specified, according to
the GETHOSTNAME(2) man page).  On my platform, this led to a zero length
hostname which caused subsequent failures.