### PR TITLE
The envelope-from address will contain a '@' character that is not al…

### DIFF
--- a/src/libspf2/spf_interpret.c
+++ b/src/libspf2/spf_interpret.c
@@ -333,7 +333,7 @@ SPF_i_set_received_spf(SPF_response_t *spf_response)
 
 		/* add in the optional envelope-from keyword */
 		if ( spf_request->env_from != NULL ) {
-			p += snprintf( p, p_end - p, " envelope-from=%s;", spf_request->env_from );
+			p += snprintf( p, p_end - p, " envelope-from=\"%s\";", spf_request->env_from );
 			if ( p_end - p <= 0 ) break;
 		}
 		


### PR DESCRIPTION
…lowed in a dot-atom and therefore must be expressed as a quoted-string.  The (now obsoleted) RFC 4408 used syntactically incorrect example for this field.  RFC 7208 corrected this.