### PR TITLE
Don't alter DNS resolution behaviour when debugging

### DIFF
--- a/src/libspf2/spf_dns_resolv.c
+++ b/src/libspf2/spf_dns_resolv.c
@@ -386,10 +386,9 @@ SPF_dns_resolv_lookup(SPF_dns_server_t *spf_dns_server,
 	for (ns_sect = 0; ns_sect < num_ns_sect; ns_sect++) {
 		/* We pass this point if:
 		 * - We are the 'answer' section.
-		 * - We are debugging.
 		 * Otherwise, we continue to the next section.
 		 */
-		if (ns_sects[ns_sect].number != ns_s_an && spf_dns_server->debug <= 1)
+		if (ns_sects[ns_sect].number != ns_s_an)
 			continue;
 
 		nrec = ns_msg_count(ns_handle, ns_sects[ns_sect].number);


### PR DESCRIPTION
If the debug level is > 1, SPF_dns_resolv_lookup was outputting the
other sections of the DNS response. While this information may be
useful, the number of records returned was influenced by whatever
the last section was.

For if the last section (e.g. ADDITIONAL) had no records then a
NO_DATA response is returned.

There's a lot of additional parsing and error handling that may
occur when processing other sections of the response, so just skip
the non-ANSWER sections even when debugging instead of attempting to
distinguish between real errors and errors occurring in debug output.