### PR TITLE
Detect res_close() (patch from maya@netbsd.org).

### DIFF
--- a/configure
+++ b/configure
@@ -13494,6 +13494,33 @@ cat >>confdefs.h <<_ACEOF
 #define HAVE_DECL_RES_NDESTROY $ac_have_decl
 _ACEOF
 
+ac_fn_c_check_decl "$LINENO" "res_close" "ac_cv_have_decl_res_close" "
+	#ifdef HAVE_SYS_TYPES_H
+	# include <sys/types.h>
+	#endif
+	#ifdef HAVE_SYS_SOCKET_H
+	# include <sys/socket.h>		/* inet_ functions / structs */
+	#endif
+	#ifdef HAVE_NETINET_IN_H
+	# include <netinet/in.h>		/* inet_ functions / structs */
+	#endif
+	#ifdef HAVE_ARPA_NAMESER_H
+	#  include <arpa/nameser.h> /* DNS HEADER struct */
+	#endif
+	#ifdef HAVE_RESOLV_H
+	# include <resolv.h>
+	#endif
+
+"
+if test "x$ac_cv_have_decl_res_close" = xyes; then :
+  ac_have_decl=1
+else
+  ac_have_decl=0
+fi
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_RES_CLOSE $ac_have_decl
+_ACEOF
 
 ac_fn_c_check_decl "$LINENO" "ns_t_spf" "ac_cv_have_decl_ns_t_spf" "
 	#ifdef HAVE_SYS_TYPES_H

--- a/configure.ac
+++ b/configure.ac
@@ -232,6 +232,23 @@ AC_CHECK_DECLS([res_ndestroy], [], [], [[
 	# include <resolv.h>
 	#endif
 	]])
+AC_CHECK_DECLS([res_close], [], [], [[
+	#ifdef HAVE_SYS_TYPES_H
+	# include <sys/types.h>
+	#endif
+	#ifdef HAVE_SYS_SOCKET_H
+	# include <sys/socket.h>		/* inet_ functions / structs */
+	#endif
+	#ifdef HAVE_NETINET_IN_H
+	# include <netinet/in.h>		/* inet_ functions / structs */
+	#endif
+	#ifdef HAVE_ARPA_NAMESER_H
+	#  include <arpa/nameser.h> /* DNS HEADER struct */
+	#endif
+	#ifdef HAVE_RESOLV_H
+	# include <resolv.h>
+	#endif
+	]])
 
 AC_CHECK_DECLS([ns_t_spf], [], [], [[
 	#ifdef HAVE_SYS_TYPES_H

--- a/src/libspf2/spf_dns_resolv.c
+++ b/src/libspf2/spf_dns_resolv.c
@@ -608,7 +608,7 @@ SPF_dns_resolv_free(SPF_dns_server_t *spf_dns_server)
 {
 	SPF_ASSERT_NOTNULL(spf_dns_server);
 
-#if ! HAVE_DECL_RES_NINIT
+#if HAVE_DECL_RES_CLOSE
 	res_close();
 #endif
 


### PR DESCRIPTION
OpenBSD seems not to have `res_close()` in the system resolver. Here's some autoconfery to detect it and only call it if present. (FWIW, OpenBSD ports checks `#ifdef __OpenBSD__` and skips the call.)