### PR TITLE
Only remove a delimiterin macro expansion if a delimiter was found

### DIFF
--- a/src/libspf2/spf_expand.c
+++ b/src/libspf2/spf_expand.c
@@ -354,7 +354,13 @@ top:
 					break;
 				p_write--;
 			}
-			p_write++;		/* Move to just after the '.' */
+			/* Move to just after the '.', but only if we have found at least
+			 * one '.' in the string. For a string without any delimiter
+			 * inside there is no '.' to remove, otherwise we would remove a
+			 * character from the payload */
+			if (num_found != 0) {
+				p_write++;
+			}
 			/* This moves the '\0' as well. */
 			len = p_read_end - p_write;
 			memmove(munged_var, p_write, len + 1);


### PR DESCRIPTION
Some macros are truncated by on character if expanded on input strings without a delimiter. This commit will fix that.

This pull request will fix #42 