### PR TITLE
More fixes

### DIFF
--- a/src/libspf2/spf_compile.c
+++ b/src/libspf2/spf_compile.c
@@ -604,7 +604,7 @@ SPF_c_parse_macro(SPF_server_t *spf_server,
 
 		default:
 			if (spf_server->debug > 3)
-				SPF_debugf("Adding illegal %%-follower '%c' at %d",
+				SPF_debugf("Adding illegal %%-follower '%c' at %zu",
 				src[idx], idx);
 			/* SPF spec says to treat it as a literal, not
 			 * SPF_E_INVALID_ESC */

--- a/src/libspf2/spf_dns_cache.c
+++ b/src/libspf2/spf_dns_cache.c
@@ -327,7 +327,7 @@ SPF_dns_cache_rr_fixup(SPF_dns_cache_config_t *spfhook,
 		char	*new_domain;
 		size_t	 new_len = strlen(domain) + 1;
 
-		if (cached_rr->domain_buf_len < new_len) {
+		if (cached_rr->domain == NULL || cached_rr->domain_buf_len < new_len) {
 			new_domain = realloc(cached_rr->domain, new_len);
 			if (new_domain == NULL)
 				return SPF_E_NO_MEMORY;

--- a/src/libspf2/spf_dns_resolv.c
+++ b/src/libspf2/spf_dns_resolv.c
@@ -268,7 +268,7 @@ SPF_dns_resolv_lookup(SPF_dns_server_t *spf_dns_server,
 	}
 #endif
 
-	responselen = 2048;
+	responselen = 65536;
 	responsebuf = (u_char *)malloc(responselen);
 	if (! responsebuf)
 		return NULL;	/* NULL always means OOM from DNS lookup. */
@@ -319,23 +319,8 @@ SPF_dns_resolv_lookup(SPF_dns_server_t *spf_dns_server,
 							domain, rr_type, 0, SPF_h_errno);
 		}
 		else if (dns_len > responselen) {
-			void	*tmp;
-			/* We managed a lookup but our buffer was too small. */
-			responselen = dns_len + (dns_len >> 1);
-#if 0
-			/* Sanity-trap - we should never hit this. */
-			if (responselen > 1048576) {	/* One megabyte. */
-				free(responsebuf);
-				return SPF_dns_rr_new_init(spf_dns_server,
-								domain, rr_type, 0, SPF_h_errno);
-			}
-#endif
-			tmp = realloc(responsebuf, responselen);
-			if (!tmp) {
-				free(responsebuf);
-				return NULL;
-			}
-			responsebuf = tmp;
+			free(responsebuf);
+			return NULL;
 		}
 		else {
 			/* We managed a lookup, and our buffer was large enough. */

--- a/src/libspf2/spf_get_exp.c
+++ b/src/libspf2/spf_get_exp.c
@@ -62,7 +62,7 @@ SPF_server_get_default_explanation(SPF_server_t *spf_server,
 	}
 	else {
 		size_t	len = sizeof(SPF_LAME_EXP) + 1;
-		if (*buflenp < len) {
+		if (*bufp == NULL || *buflenp < len) {
 			char	*tmp = realloc(*bufp, len);
 			if (tmp == NULL)
 				return SPF_E_NO_MEMORY;


### PR DESCRIPTION
A couple of minor issues.

The DNS responses should be limited to 65536 bytes already so while it doubles memory allocation indefinitely it shouldn't be possible to get out of control.

There's a warning from `scan-build` about some string pointers that could be `NULL`, but those will never actually be `NULL`.